### PR TITLE
Librechat v0.5.0

### DIFF
--- a/charts/librechat-rag-api/Chart.yaml
+++ b/charts/librechat-rag-api/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.4
+version: 0.1.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/librechat-rag-api/Chart.yaml
+++ b/charts/librechat-rag-api/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.4
+version: 0.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -28,6 +28,6 @@ home: https://blue-atlas.de
 
 dependencies:
   - name: postgresql
-    version: "15.5.5"
+    version: "15.5.21"
     condition: postgresql.enabled
     repository: https://charts.bitnami.com/bitnami

--- a/charts/librechat-rag-api/templates/service.yaml
+++ b/charts/librechat-rag-api/templates/service.yaml
@@ -4,6 +4,8 @@ metadata:
   name: {{ include "rag.fullname" . }}
   labels:
     {{- include "rag.labels" . | nindent 4 }}
+  annotations:
+  {{ .Values.service.annotations | toYaml | indent 4 }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/charts/librechat-rag-api/values.yaml
+++ b/charts/librechat-rag-api/values.yaml
@@ -2,15 +2,13 @@
 # provide context-aware responses based on user-uploaded files
 rag:
   enabled: true
-  # Currently only lite is supported. This allows leveraging RAGs from Remote Endpoint like azure or 
-  mode: lite
   existingSecret: ''
   configEnv:
     DB_PORT: '5432'
     EMBEDDINGS_PROVIDER: openai
 
 image:
-  repository: danny-avila/librechat-rag-api-dev # -lite will be added if mode is lite
+  repository: danny-avila/librechat-rag-api-dev-lite # there is rag-api-dev and rag-api-dev-lite. currently only lite is docuimented
   registry: ghcr.io
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
@@ -51,6 +49,7 @@ securityContext: {}
 service:
   type: ClusterIP
   port: 8000
+  annotations: {}
 
 
 resources: {}

--- a/charts/librechat/Chart.yaml
+++ b/charts/librechat/Chart.yaml
@@ -22,7 +22,7 @@ version: 1.5.0
 # It is recommended to use it with quotes.
 
 # renovate: image=ghcr.io/danny-avila/librechat
-appVersion: "v0.7.3-rc1"
+appVersion: "v0.7.4"
 
 home: https://blue-atlas.de
 

--- a/charts/librechat/Chart.yaml
+++ b/charts/librechat/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.4.4
+version: 1.5.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -28,7 +28,7 @@ home: https://blue-atlas.de
 
 dependencies:
   - name: mongodb
-    version: "15.6.6"
+    version: "15.6.18"
     condition: mongodb.enabled
     repository: "https://charts.bitnami.com/bitnami"
   - name: meilisearch

--- a/charts/librechat/Chart.yaml
+++ b/charts/librechat/Chart.yaml
@@ -36,6 +36,6 @@ dependencies:
     condition: meilisearch.enabled
     repository: "https://meilisearch.github.io/meilisearch-kubernetes"
   - name: librechat-rag-api
-    version: "0.1.4"
+    version: "0.1.5"
     condition: librechat-rag-api.enabled
     repository: file://../librechat-rag-api #"https://charts.blue-atlas.de"

--- a/charts/librechat/templates/service.yaml
+++ b/charts/librechat/templates/service.yaml
@@ -4,6 +4,8 @@ metadata:
   name: {{ include "librechat.fullname" . }}
   labels:
     {{- include "librechat.labels" . | nindent 4 }}
+  annotations:
+  {{ .Values.service.annotations | toYaml | indent 4 }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/charts/librechat/values.yaml
+++ b/charts/librechat/values.yaml
@@ -158,6 +158,7 @@ securityContext:
 service:
   type: ClusterIP
   port: 3080
+  annotations: {}
 
 ingress:
   enabled: true


### PR DESCRIPTION
- Add Annotations to Librechat and Rag API Service #23 
- Fix rag API tag to use Lite instead of normal
- Bump Deps
- Bump Librechat to [v0.7.4](https://www.librechat.ai/changelog/v0.7.4) 