### PR TITLE
charts/librechat/templates: fix notes rendering for ClusterIP

### DIFF
--- a/charts/librechat/templates/NOTES.txt
+++ b/charts/librechat/templates/NOTES.txt
@@ -15,7 +15,7 @@
   export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "librechat.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
   echo http://$SERVICE_IP:{{ .Values.service.port }}
 {{- else if contains "ClusterIP" .Values.service.type }}
-  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "librechat.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "librechat.fullname" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
   export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
   echo "Visit http://127.0.0.1:8080 to use your application"
   kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT


### PR DESCRIPTION
Currently, chart installation fails with the following error:
```
Error: UPGRADE FAILED: template: librechat/templates/NOTES.txt:18:104: executing "librechat/templates/NOTES.txt" at <include "librechat.name" .>: error calling include: template: no template "librechat.name" associated with template "gotpl"
```
This is reproducible with the followint values:
```
ingress:
  enabled: false

service:
  type: ClusterIP
```

PR fixes template used for notes rendering.