### PR TITLE
charts/librechat/templates: add an option to override deployment update strategy

### DIFF
--- a/charts/librechat/templates/deployment.yaml
+++ b/charts/librechat/templates/deployment.yaml
@@ -6,6 +6,9 @@ metadata:
     {{- include "librechat.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  {{- if .Values.updateStrategy }}
+  strategy: {{- toYaml .Values.updateStrategy | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "librechat.selectorLabels" . | nindent 6 }}

--- a/charts/librechat/values.yaml
+++ b/charts/librechat/values.yaml
@@ -226,7 +226,7 @@ tolerations: []
 
 affinity: {}
 
-# A strategy for LibreChat deployment updates
+# Strategy for LibreChat deployment updates
 updateStrategy:
   type: RollingUpdate
 

--- a/charts/librechat/values.yaml
+++ b/charts/librechat/values.yaml
@@ -226,6 +226,10 @@ tolerations: []
 
 affinity: {}
 
+# A strategy for LibreChat deployment updates
+updateStrategy:
+  type: RollingUpdate
+
 # MongoDB Parameters
 mongodb:
   enabled: true


### PR DESCRIPTION
Ability to overwrite update strategy is useful when using persistence for images. 
Setting `strategy.type: Recreate` is needed in this case in order to recreate pod with the same PVC attached if PVC type is set to `ReadWriteOnce`.

Default value corresponds to default option for deployments, so this does not change current behaviour of the chart.