### PR TITLE
add volume and volumemount to deployment

### DIFF
--- a/charts/librechat-rag-api/Chart.yaml
+++ b/charts/librechat-rag-api/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.1
+version: 0.2.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/librechat-rag-api/values.yaml
+++ b/charts/librechat-rag-api/values.yaml
@@ -73,18 +73,6 @@ resources: {}
 #     path: /
 #     port: http
 
-# Additional volumes on the output Deployment definition.
-volumes: []
-# - name: foo
-#   secret:
-#     secretName: mysecret
-#     optional: false
-
-# Additional volumeMounts on the output Deployment definition.
-volumeMounts: []
-# - name: foo
-#   mountPath: "/etc/foo"
-#   readOnly: true
 
 nodeSelector: {}
 

--- a/charts/librechat/Chart.yaml
+++ b/charts/librechat/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.8.1
+version: 1.8.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -36,6 +36,6 @@ dependencies:
     condition: meilisearch.enabled
     repository: "https://meilisearch.github.io/meilisearch-kubernetes"
   - name: librechat-rag-api
-    version: "0.2.1"
+    version: "0.2.2"
     condition: librechat-rag-api.enabled
     repository: file://../librechat-rag-api #"https://charts.blue-atlas.de"

--- a/charts/librechat/templates/deployment.yaml
+++ b/charts/librechat/templates/deployment.yaml
@@ -61,6 +61,9 @@ spec:
           - name: image-volume
             mountPath: "/app/client/public/images"
           {{- end }}
+          {{- if .Values.volumeMounts }}
+          {{- toYaml .Values.volumeMounts | nindent 10 }}
+          {{- end }}
           envFrom:
           - configMapRef:
               name: {{ include "librechat.fullname" $ }}-configenv
@@ -83,6 +86,9 @@ spec:
       - name: image-volume
         persistentVolumeClaim:
           claimName: {{ include "librechat.fullname" $ }}-images
+      {{- end }}
+      {{- if .Values.volumes }}
+      {{- toYaml .Values.volumes | nindent 6 }}
       {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:


### PR DESCRIPTION
the values file has volume and volumemount definitions but they aren't used in the deployment template

```
# Additional volumes on the output Deployment definition.
volumes: []
# - name: foo
#   secret:
#     secretName: mysecret
#     optional: false

# Additional volumeMounts on the output Deployment definition.
volumeMounts: []
# - name: foo
#   mountPath: "/etc/foo"
#   readOnly: true
```