### PR TITLE
Added the missing chart.lock file, and updated CI pipeline to include…

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,6 +26,12 @@ jobs:
         run: |
           helm repo add bitnami https://charts.bitnami.com/bitnami
 
+      - name: Build chart dependencies
+        run: |
+          for chart in charts/*/; do
+            helm dependency build "$chart"
+          done
+
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.7.0
         with:

--- a/charts/librechat/Chart.lock
+++ b/charts/librechat/Chart.lock
@@ -1,0 +1,12 @@
+dependencies:
+- name: mongodb
+  repository: https://charts.bitnami.com/bitnami
+  version: 16.3.0
+- name: meilisearch
+  repository: https://meilisearch.github.io/meilisearch-kubernetes
+  version: 0.7.0
+- name: librechat-rag-api
+  repository: file://../librechat-rag-api
+  version: 0.5.0
+digest: sha256:0981cfe737e73ecba5df331a50c70b8f45f2d4505f380c89ea1d9e9d752661bf
+generated: "2025-04-22T13:49:24.416819+02:00"


### PR DESCRIPTION
### Summary

This PR attempts to fix a packaging issue introduced in `librechat` chart version 1.8.9 where the `postgresql` subchart (required by `librechat-rag-api`) was not being included in the final Helm release artifact.

### Cause

The `librechat` chart was missing a `Chart.lock` file, and the GitHub Actions release workflow did not run `helm dependency build` prior to invoking `chart-releaser-action`. As a result, the `charts/` folder was incomplete and critical transitive dependencies (like `postgresql`) were excluded from the final `.tgz`.

### Fix

- Ran `helm dependency update charts/librechat` to resolve all dependencies
- Committed the resulting `Chart.lock` file
- Verified locally that packaging now includes all expected subcharts (including `postgresql`). 

### CI Update

I have included a change to the github action that will run `helm dependency build` for all charts in ./charts