### PR TITLE
Pass envFrom from values.yaml to Deployment

### DIFF
--- a/charts/librechat-rag-api/Chart.yaml
+++ b/charts/librechat-rag-api/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.1
+version: 0.6.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/librechat-rag-api/templates/rag-deployment.yaml
+++ b/charts/librechat-rag-api/templates/rag-deployment.yaml
@@ -50,6 +50,9 @@ spec:
           envFrom:
           - configMapRef:
               name: {{ include "rag.fullname" $ }}-config
+          {{- with .Values.rag.envFrom }} 
+          {{ toYaml . | nindent 10 }}
+          {{- end }}
           {{- if .Values.rag.existingSecret }}
           - secretRef:
               name: {{ .Values.rag.existingSecret }}

--- a/charts/librechat-rag-api/values.yaml
+++ b/charts/librechat-rag-api/values.yaml
@@ -3,6 +3,7 @@
 rag:
   enabled: true
   existingSecret: ''
+  envFrom: {}
   configEnv:
     DB_PORT: '5432'
     EMBEDDINGS_PROVIDER: openai

--- a/charts/librechat-rag-api/values.yaml
+++ b/charts/librechat-rag-api/values.yaml
@@ -3,7 +3,7 @@
 rag:
   enabled: true
   existingSecret: ''
-  envFrom: {}
+  envFrom: [] 
   configEnv:
     DB_PORT: '5432'
     EMBEDDINGS_PROVIDER: openai

--- a/charts/librechat/Chart.yaml
+++ b/charts/librechat/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.8.10
+version: 1.9.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/librechat/templates/deployment.yaml
+++ b/charts/librechat/templates/deployment.yaml
@@ -67,6 +67,9 @@ spec:
           envFrom:
           - configMapRef:
               name: {{ include "librechat.fullname" $ }}-configenv
+          {{- with .Values.global.librechat.envFrom }} 
+          {{ toYaml . | nindent 10 }}
+          {{- end }}
           {{- if .Values.global.librechat.existingSecretName }}
           - secretRef:
               name: {{ .Values.global.librechat.existingSecretName }}

--- a/charts/librechat/values.yaml
+++ b/charts/librechat/values.yaml
@@ -9,7 +9,7 @@ replicaCount: 1
 global:
   librechat:
     existingSecretName: "librechat-credentials-env"
-    envFrom: {} 
+    envFrom: [] 
     # Used for Setting the Right Key, can be something like AZURE_API_KEY, if Azure OpenAI is used
     existingSecretApiKey: OPENAI_API_KEY
 

--- a/charts/librechat/values.yaml
+++ b/charts/librechat/values.yaml
@@ -9,6 +9,7 @@ replicaCount: 1
 global:
   librechat:
     existingSecretName: "librechat-credentials-env"
+    envFrom: {} 
     # Used for Setting the Right Key, can be something like AZURE_API_KEY, if Azure OpenAI is used
     existingSecretApiKey: OPENAI_API_KEY
 


### PR DESCRIPTION
There are scenarios where a single source for environment variables isn’t enough. To accommodate deployments that need to pull variables from multiple places, this PR introduces global.librechat.envFrom in values.yaml. Chart users can now list any number of envFrom entries (ConfigMaps, Secrets, etc.) there, and the array is forwarded to the Deployment so the pod picks them up automatically.